### PR TITLE
fix missing header issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Building requires
 build-essential
 git
 libsdl1.2-dev
+chip-mali-userspace
 
 License
 ----

--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,8 @@ sudo apt-get update && \
 sudo apt-get -y install \
 build-essential \
 git \
-libsdl1.2-dev
+libsdl1.2-dev \
+chip-mali-userspace
 
 git clone https://github.com/xobs/mcrpi-wrapper
 mkdir mcrpi-wrapper


### PR DESCRIPTION
Maybe because of my initial chip config, which had OS installed in headless mode, I got an 'missing file' type of error while trying to install minecraft-pi the first time:

```
gcc -c bcm_host.c -o bcm_host.o -fPIC `sdl-config --cflags`
bcm_host.c:3:21: fatal error: EGL/egl.h: No such file or directory
 #include <EGL/egl.h>
                     ^
compilation terminated.
Makefile:2: recipe for target 'all' failed
make: *** [all] Error 1
```
By reading the [https://github.com/thp/eglo](https://github.com/thp/eglo) I found out, that the chip-mali-userspace was a dependence, and my system was lacking it. So the installation script was updated and the minecraft-pi was installed.